### PR TITLE
Add initial OpenAI CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Rename this file to .env and add your OpenAI API key
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -115,3 +115,15 @@ AI: I'll list the configured nginx sites.
 ```
 
 This is essentially a smart wrapper around the command line that makes server management more conversational and less error-prone.
+## Getting Started
+
+1. Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+2. Copy `.env.example` to `.env` and add your OpenAI API key.
+3. Run the chat CLI:
+```bash
+python cli.py
+```
+

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,43 @@
+import os
+import openai
+from dotenv import load_dotenv
+
+
+def main():
+    load_dotenv()
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        print("OPENAI_API_KEY not set. Please set it in your environment or .env file.")
+        return
+    openai.api_key = api_key
+
+    system_prompt = (
+        "You are Cortana, a helpful assistant that can help with server commands."
+    )
+    messages = [
+        {"role": "system", "content": system_prompt}
+    ]
+    print("Type 'exit' to quit")
+    while True:
+        try:
+            user_input = input("You: ")
+        except EOFError:
+            break
+        if user_input.strip().lower() in {"exit", "quit"}:
+            break
+        messages.append({"role": "user", "content": user_input})
+        try:
+            response = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=messages,
+            )
+        except Exception as e:
+            print(f"Error: {e}")
+            break
+        reply = response.choices[0].message["content"].strip()
+        print(f"AI: {reply}")
+        messages.append({"role": "assistant", "content": reply})
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+openai>=1.0.0
+python-dotenv


### PR DESCRIPTION
## Summary
- create `cli.py` with a simple chat loop using OpenAI
- add requirements
- include `.env.example` for API secrets
- document setup and usage in README

## Testing
- `pip install -r requirements.txt`
- `python cli.py` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_685c4de2c048832ea6a1883f7bb5f21c