### PR TITLE
Add interactive command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ AI: I'll list the configured nginx sites.
 ```
 
 This is essentially a smart wrapper around the command line that makes server management more conversational and less error-prone.
+
+### Running Commands
+
+When the assistant replies with a command inside a code block, the CLI shows you the command and asks for confirmation:
+
+```
+Command: ls -la
+Execute? (press enter for yes, 'n' for no):
+```
+
+Press **Enter** to run the command and see the live output, or type **n** to skip.
 ## Getting Started
 
 1. Install dependencies:

--- a/cli.py
+++ b/cli.py
@@ -1,6 +1,32 @@
 import os
+import re
+import subprocess
+
 import openai
 from dotenv import load_dotenv
+
+
+def extract_command(text: str) -> str | None:
+    """Extract the first shell command found in a fenced code block."""
+    match = re.search(r"```(?:bash\n)?([^`]+)```", text, re.DOTALL)
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+def run_command(command: str) -> None:
+    """Run a shell command and stream output."""
+    process = subprocess.Popen(
+        command,
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if process.stdout:
+        for line in process.stdout:
+            print(line, end="")
+    process.wait()
 
 
 def main():
@@ -12,7 +38,9 @@ def main():
     openai.api_key = api_key
 
     system_prompt = (
-        "You are Cortana, a helpful assistant that can help with server commands."
+        "You are Cortana, a helpful assistant that suggests shell commands for"
+        " server management. When you provide a command, put only the command"
+        " itself inside a fenced code block."
     )
     messages = [
         {"role": "system", "content": system_prompt}
@@ -37,6 +65,16 @@ def main():
         reply = response.choices[0].message["content"].strip()
         print(f"AI: {reply}")
         messages.append({"role": "assistant", "content": reply})
+
+        command = extract_command(reply)
+        if command:
+            print(f"\nCommand: {command}")
+            approve = input("Execute? (press enter for yes, 'n' for no): ")
+            if approve.strip().lower() != "n":
+                print(f"Running: {command}")
+                run_command(command)
+            else:
+                print("Command skipped.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update README with instructions on running commands
- allow CLI to detect commands in replies, confirm and run them

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile cli.py`
- `python cli.py <<'EOF'
exit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685c4f637120832e9a36c2a9e46f44d1