### PR TITLE
Add YAML rules system with tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ openai>=1.0.0
 python-dotenv
 pytest
 pydantic
+pyyaml


### PR DESCRIPTION
## Summary
- implement rule checking in `cli.py`
- add PyYAML dependency
- capture prompts in CLI tests
- test blocking and confirm behavior via YAML rules

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c611430fc832ea4727c129454bd5f