### PR TITLE
Add command outcome tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ This is a simple AI agent that sits in your terminal and helps with Linux comman
 - Always asks permission before running anything potentially risky
 - Responses are structured JSON parsed with Pydantic
 - Captures results and learns from what works/doesn’t work
+- Tracks command success or failure to refine future suggestions
 
 **Learning System**
 
 - Keeps a knowledge file about your server (OS, installed packages, configurations)
 - Remembers successful setups and configurations
+- Records command outcomes (success or failure) in the knowledge base
 - Updates its understanding as it discovers new things about your system
 
 **Safety Controls**

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -10,7 +10,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 # Ensure cli imports without real openai dependency
 fake_openai = types.SimpleNamespace()
-sys.modules.setdefault('openai', fake_openai)
+sys.modules.setdefault("openai", fake_openai)
 
 import cli
 
@@ -40,8 +40,19 @@ def test_update_knowledge_appends_command(tmp_path, monkeypatch):
     path = tmp_path / "kb.json"
     monkeypatch.setattr(cli, "gather_system_info", lambda: {"os": "FakeOS"})
     data = cli.load_knowledge(str(path))
-    cli.update_knowledge(str(path), data, "echo hi", "hi\n")
+    cli.update_knowledge(str(path), data, "echo hi", "hi\n", True)
     with open(path) as f:
         saved = json.load(f)
-    assert saved["commands"][-1] == {"command": "echo hi", "output": "hi\n"}
+    assert saved["commands"][-1] == {
+        "command": "echo hi",
+        "output": "hi\n",
+        "success": True,
+    }
 
+
+def test_run_command_success_and_failure():
+    out, success = cli.run_command("echo test")
+    assert success
+    assert out.strip() == "test"
+    out2, success2 = cli.run_command("false")
+    assert not success2


### PR DESCRIPTION
## Summary
- track command success/failure in `server_knowledge.json`
- include recent command history in system prompt
- store command outcomes in conversation history
- adjust tests for new functionality and add coverage
- document command outcome tracking in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c63d0bf5c832e87aef9919f53a796