### PR TITLE
Add dangerous command safety checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This is a simple AI agent that sits in your terminal and helps with Linux comman
 **Safety Controls**
 
 - Rules file that you can edit to set boundaries
-- Built-in safety checks for dangerous commands
+- Built-in safety checks for dangerous commands (e.g. detects `rm -rf /`)
 - Always shows you what it’s about to run before executing
 
 ## Main Use Case


### PR DESCRIPTION
## Summary
- detect dangerous command patterns like `rm -rf /`
- warn users before allowing execution
- document safety check behaviour
- test dangerous command detection and interaction with rule system

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c65cbfca8832ea887c7b331a77e6c