### PR TITLE
Add async command support and JSON error handling

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -277,3 +277,19 @@ def test_dangerous_command_blocked(monkeypatch, tmp_path):
 
     assert "Command blocked by safety rules" in out
     assert "Dangerous command detected" not in out
+
+
+def test_invalid_json_response(monkeypatch, tmp_path):
+    knowledge = tmp_path / "kb.json"
+    out = run_cli_single_question(
+        monkeypatch,
+        "hello",
+        "not-json",
+        str(knowledge),
+        extra_inputs=[],
+    )
+    assert "Invalid JSON response from AI." in out
+    assert "not-json" in out
+    with open(knowledge) as f:
+        data = json.load(f)
+    assert data["commands"] == []

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -3,6 +3,7 @@ import json
 import sys
 import types
 import tempfile
+import asyncio
 
 import pytest
 
@@ -56,3 +57,18 @@ def test_run_command_success_and_failure():
     assert out.strip() == "test"
     out2, success2 = cli.run_command("false")
     assert not success2
+
+
+def test_run_command_async_success_and_failure():
+    out, success = asyncio.run(cli.run_command_async("echo async"))
+    assert success
+    assert out.strip() == "async"
+    out2, success2 = asyncio.run(cli.run_command_async("false"))
+    assert not success2
+
+
+def test_check_command_rules():
+    rules = {"blocked": [], "confirm": ["apt install"]}
+    assert cli.check_command_rules("rm file", {"blocked": ["rm"], "confirm": []}) == "block"
+    assert cli.check_command_rules("sudo apt install htop", rules) == "confirm"
+    assert cli.check_command_rules("rm -rf /", rules) == "danger"


### PR DESCRIPTION
## Summary
- add `run_command_async` for asynchronous command execution
- handle invalid JSON responses from the AI with a clear message
- test invalid JSON handling
- test async command execution
- test rule checking logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c68549d74832ea79fe5a7de5c1abc