### PR TITLE
Add automated planning and execution loop

### DIFF
--- a/planner.py
+++ b/planner.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass, asdict
+from typing import List
+import json
+import os
+import openai
+
+PLAN_PROMPT = (
+    "Break the following task into a short sequence of shell commands. "
+    "Respond in JSON with a 'steps' array where each item has 'description' and 'command'."
+)
+
+@dataclass
+class PlanStep:
+    description: str
+    command: str
+    status: str = "pending"
+    output: str = ""
+    success: bool | None = None
+
+
+def save_plan(path: str, steps: List[PlanStep]) -> None:
+    data = [asdict(s) for s in steps]
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def load_plan(path: str) -> List[PlanStep]:
+    if not os.path.exists(path):
+        return []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return [PlanStep(**d) for d in data]
+    except Exception:
+        return []
+
+
+def generate_plan(task: str) -> List[PlanStep]:
+    """Use the language model to create a plan for the given task."""
+    messages = [
+        {"role": "system", "content": PLAN_PROMPT},
+        {"role": "user", "content": task},
+    ]
+    response = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=messages)
+    raw = response.choices[0].message["content"].strip()
+    data = json.loads(raw)
+    steps = [PlanStep(**s) for s in data.get("steps", [])]
+    return steps
+
+
+def execute_plan(
+    steps: List[PlanStep],
+    plan_path: str,
+    knowledge: dict,
+    knowledge_path: str,
+    run_command_fn,
+    update_knowledge_fn,
+) -> List[PlanStep]:
+    """Run each pending step sequentially."""
+    for step in steps:
+        if step.status != "pending":
+            continue
+        print(f"Step: {step.description}")
+        print(f"Command: {step.command}")
+        output, success = run_command_fn(step.command)
+        step.output = output
+        step.success = success
+        step.status = "done" if success else "failed"
+        update_knowledge_fn(knowledge_path, knowledge, step.command, output, success)
+        save_plan(plan_path, steps)
+        if not success:
+            print("Step failed. Stopping execution.")
+            break
+    return steps

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,41 @@
+import json
+import sys
+import types
+import os
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+fake_openai = types.SimpleNamespace(ChatCompletion=types.SimpleNamespace())
+sys.modules.setdefault("openai", fake_openai)
+
+import cli
+import planner
+
+
+def test_execute_plan_success(monkeypatch, tmp_path):
+    knowledge_path = tmp_path / "kb.json"
+    planner.save_plan(str(tmp_path / "plan.json"), [planner.PlanStep(description="step", command="echo hi")])
+    monkeypatch.setattr(cli, "run_command", lambda cmd: ("hi\n", True))
+    monkeypatch.setattr(cli, "update_knowledge", lambda *a, **k: None)
+    knowledge = {"system": {}, "commands": []}
+    steps = planner.load_plan(str(tmp_path / "plan.json"))
+    planner.execute_plan(steps, str(tmp_path / "plan.json"), knowledge, str(knowledge_path), cli.run_command, cli.update_knowledge)
+    assert steps[0].status == "done"
+
+
+def test_execute_plan_failure(monkeypatch, tmp_path):
+    plan_file = tmp_path / "plan.json"
+    planner.save_plan(str(plan_file), [
+        planner.PlanStep(description="one", command="ok"),
+        planner.PlanStep(description="two", command="fail"),
+    ])
+    monkeypatch.setattr(cli, "run_command", lambda c: ("", c == "ok"))
+    monkeypatch.setattr(cli, "update_knowledge", lambda *a, **k: None)
+    knowledge = {"system": {}, "commands": []}
+    steps = planner.load_plan(str(plan_file))
+    planner.execute_plan(steps, str(plan_file), knowledge, str(tmp_path/"kb.json"), cli.run_command, cli.update_knowledge)
+    assert steps[0].status == "done"
+    assert steps[1].status == "failed"
+


### PR DESCRIPTION
## Summary
- implement a new `planner` module with plan generation and step execution
- extend `cli` with argument parsing and ability to run/resume plans stored in `task_plan.json`
- add integration tests for the planning loop

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c6e19282c832e9e03669624505d06