### PR TITLE
Implement persistent shell features with planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ This is a simple AI agent that sits in your terminal and helps with Linux comman
 - Responses are structured JSON parsed with Pydantic
 - Captures results and learns from what works/doesn’t work
 - Tracks command success or failure to refine future suggestions
+- Maintains the current working directory across commands
+- Built-in `edit` command to modify files from the CLI
+- Multi-step automation plans via the `plan` keyword or `--plan` option
 
 **Learning System**
 

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -72,3 +72,22 @@ def test_check_command_rules():
     assert cli.check_command_rules("rm file", {"blocked": ["rm"], "confirm": []}) == "block"
     assert cli.check_command_rules("sudo apt install htop", rules) == "confirm"
     assert cli.check_command_rules("rm -rf /", rules) == "danger"
+
+
+def test_persistent_cd(monkeypatch, tmp_path):
+    cli.CURRENT_DIR = str(tmp_path)
+    out, success = cli.run_command("pwd")
+    assert success
+    assert out.strip() == str(tmp_path)
+    cli.run_command("mkdir sub")
+    cli.run_command("cd sub")
+    out2, success2 = cli.run_command("pwd")
+    assert success2
+    assert out2.strip() == str(tmp_path / "sub")
+
+
+def test_edit_file(monkeypatch, tmp_path):
+    cli.CURRENT_DIR = str(tmp_path)
+    out, success = cli.run_command("edit file.txt hello")
+    assert success
+    assert (tmp_path / "file.txt").read_text() == "hello"


### PR DESCRIPTION
## Summary
- keep current working directory across commands
- add simple `edit` command for quick file changes
- support planning via `--plan` flag or `plan` keyword
- document new features in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c7646eddc832ea2e0c54ec280ca31