### PR TITLE
Improve feedback and planning utilities

### DIFF
--- a/planner.py
+++ b/planner.py
@@ -72,3 +72,29 @@ def execute_plan(
             print("Step failed. Stopping execution.")
             break
     return steps
+
+
+def interactive_edit_plan(path: str) -> None:
+    steps = load_plan(path)
+    if not steps:
+        print("No plan found.")
+        return
+    while True:
+        for idx, s in enumerate(steps, 1):
+            print(f"{idx}. {s.description}: {s.command} [{s.status}]")
+        choice = input("Edit step number (enter to finish): ").strip()
+        if not choice:
+            break
+        try:
+            i = int(choice) - 1
+            step = steps[i]
+        except (ValueError, IndexError):
+            print("Invalid step.")
+            continue
+        desc = input(f"Description [{step.description}]: ").strip()
+        cmd = input(f"Command [{step.command}]: ").strip()
+        if desc:
+            step.description = desc
+        if cmd:
+            step.command = cmd
+    save_plan(path, steps)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -289,6 +289,7 @@ def test_invalid_json_response(monkeypatch, tmp_path):
         extra_inputs=[],
     )
     assert "Invalid JSON response from AI." in out
+    assert "rephrasing" in out
     assert "not-json" in out
     with open(knowledge) as f:
         data = json.load(f)

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -2,6 +2,7 @@ import json
 import sys
 import types
 import os
+import builtins
 
 import pytest
 
@@ -61,4 +62,15 @@ def test_execute_plan_with_cd_and_edit(tmp_path, monkeypatch):
     )
     assert (tmp_path / "sub" / "hi.txt").read_text() == "hi"
     assert steps[3].output.strip() == "hi"
+
+
+def test_interactive_edit_plan(monkeypatch, tmp_path):
+    path = tmp_path / "plan.json"
+    planner.save_plan(str(path), [planner.PlanStep(description="one", command="cmd")])
+    inputs = iter(["1", "desc", "newcmd", ""])
+    monkeypatch.setattr(builtins, "input", lambda _="": next(inputs))
+    planner.interactive_edit_plan(str(path))
+    steps = planner.load_plan(str(path))
+    assert steps[0].description == "desc"
+    assert steps[0].command == "newcmd"
 


### PR DESCRIPTION
## Summary
- expand gathered system info
- record command success statistics
- show exit codes when commands fail
- offer interactive editing of saved plans
- improve invalid JSON error message
- test new behaviors

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c7c48d624832eab1aa8009836821c