### PR TITLE
Add plan approval and step confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This is a simple AI agent that sits in your terminal and helps with Linux comman
 
 - AI can run commands for you and show live output
 - Shows generated command preview with simple “yes (enter) / no” approval
+- Steps in an automation plan also require approval before running
+- Declining a step pauses the plan so it can be resumed or edited later
 - Always asks permission before running anything potentially risky
 - Responses are structured JSON parsed with Pydantic
 - Captures results and learns from what works/doesn’t work
@@ -24,6 +26,7 @@ This is a simple AI agent that sits in your terminal and helps with Linux comman
 - Maintains the current working directory across commands
 - Built-in `edit` command to modify files from the CLI
 - Multi-step automation plans via the `plan` keyword or `--plan` option
+- Plans are shown for approval and can be updated before execution
 
 **Learning System**
 

--- a/planner.py
+++ b/planner.py
@@ -55,6 +55,8 @@ def execute_plan(
     knowledge_path: str,
     run_command_fn,
     update_knowledge_fn,
+    confirm_each_step: bool = False,
+    input_fn=input,
 ) -> List[PlanStep]:
     """Run each pending step sequentially."""
     for step in steps:
@@ -62,6 +64,13 @@ def execute_plan(
             continue
         print(f"Step: {step.description}")
         print(f"Command: {step.command}")
+        if confirm_each_step:
+            ans = input_fn("Run this command? (press enter for yes, 'n' to skip): ").strip().lower()
+            if ans == "n":
+                print("Step declined. Pausing plan.")
+                step.status = "pending"
+                save_plan(plan_path, steps)
+                break
         output, success = run_command_fn(step.command)
         step.output = output
         step.success = success


### PR DESCRIPTION
## Summary
- require approval for generated plans
- allow updating the plan before running
- confirm each step when executing plans
- pause execution if a step is declined
- document plan pausing
- test execute_plan step confirmation

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c7f621874832eb6fb8fcd4b8433f7