### PR TITLE
Fix OpenAI API usage

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -391,7 +391,7 @@ def main():
     if not api_key:
         print("OPENAI_API_KEY not set. Please set it in your environment or .env file.")
         return
-    openai.api_key = api_key
+    client = openai.OpenAI(api_key=api_key)
 
     knowledge_file = os.getenv("CORTANA_KNOWLEDGE_FILE", "server_knowledge.json")
     knowledge = load_knowledge(knowledge_file)
@@ -461,7 +461,7 @@ def main():
             continue
         messages.append({"role": "user", "content": user_input})
         try:
-            response = openai.ChatCompletion.create(
+            response = client.chat.completions.create(
                 model="gpt-3.5-turbo",
                 messages=messages,
             )

--- a/planner.py
+++ b/planner.py
@@ -41,7 +41,8 @@ def generate_plan(task: str) -> List[PlanStep]:
         {"role": "system", "content": PLAN_PROMPT},
         {"role": "user", "content": task},
     ]
-    response = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=messages)
+    client = openai.OpenAI()
+    response = client.chat.completions.create(model="gpt-3.5-turbo", messages=messages)
     raw = response.choices[0].message["content"].strip()
     data = json.loads(raw)
     steps = [PlanStep(**s) for s in data.get("steps", [])]

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -8,7 +8,14 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-fake_openai = types.SimpleNamespace(ChatCompletion=types.SimpleNamespace())
+class FakeOpenAIClient:
+    def __init__(self, create_fn=None):
+        self.chat = types.SimpleNamespace(
+            completions=types.SimpleNamespace(create=create_fn)
+        )
+
+
+fake_openai = types.SimpleNamespace(OpenAI=lambda **_: FakeOpenAIClient())
 sys.modules.setdefault("openai", fake_openai)
 
 import cli


### PR DESCRIPTION
## Summary
- update cli and planner to use new `openai.OpenAI` client
- adjust tests for new OpenAI interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e9bbb30c832eae7452680e158da1