### PR TITLE
Fix openai message content extraction

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -468,7 +468,11 @@ def main():
         except Exception as e:
             print(f"Error: {e}")
             break
-        raw = response.choices[0].message["content"].strip()
+        msg = response.choices[0].message
+        if isinstance(msg, dict):
+            raw = msg["content"].strip()
+        else:
+            raw = msg.content.strip()
         try:
             data = CortanaResponse.model_validate_json(raw)
         except ValidationError as e:


### PR DESCRIPTION
## Summary
- support message objects in `cli.py` when using newer OpenAI SDK

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861eb1d1824832ebb65f3166d926447